### PR TITLE
cigarWidthAlongReferenceSpace() is now in the new cigarillo package and was renamed cigar_extent_along_ref()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: csaw
 Version: 1.43.1
-Date: 2025-06-20
+Date: 2026-07-13
 Title: ChIP-Seq Analysis with Windows
 Authors@R:
     c(person("Aaron", "Lun", role=c("aut", "cre"), email = "infinite.monkeys.with.keyboards@gmail.com"),
@@ -29,7 +29,7 @@ Suggests:
     TxDb.Mmusculus.UCSC.mm10.knownGene,
     testthat,
     GenomicFeatures,
-    GenomicAlignments,
+    cigarillo,
     knitr,
     BiocStyle,
     rmarkdown,

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -52,8 +52,8 @@ simsam <- function(f.out, chr, pos, strands, chromosomes, mapq=199, is.dup=NULL,
 
         mate.chr.size <- chromosomes[mate.chr] + 1L # Keep above mate.chr reassignment!
         mate.chr <- ifelse(mate.chr==stuff$CHR, "=", mate.chr)
-        my.cigar <- GenomicAlignments::cigarWidthAlongReferenceSpace(stuff$CIGAR)
-        mate.cigar <- GenomicAlignments::cigarWidthAlongReferenceSpace(stuff$CIGAR[counterpart])
+        my.cigar <- cigarillo::cigar_extent_along_ref(stuff$CIGAR)
+        mate.cigar <- cigarillo::cigar_extent_along_ref(stuff$CIGAR[counterpart])
 
         isize <- pmin(pmax(mate.pos + mate.cigar, pos + my.cigar), mate.chr.size) - pmin(mate.pos, pos)
         isize[mate.pos < pos] <- isize[mate.pos < pos]*-1

--- a/tests/testthat/test-int_extract.R
+++ b/tests/testthat/test-int_extract.R
@@ -27,7 +27,7 @@ SREF <- function(bam, param) {
         out <- lapply(out, "[", keep)
     }
 
-    out$rwidth <- GenomicAlignments::cigarWidthAlongReferenceSpace(out$cigar)
+    out$rwidth <- cigarillo::cigar_extent_along_ref(out$cigar)
 
     if (length(param$discard)) {
         pretend <- GRanges(out$rname, IRanges(out$pos, out$pos + out$rwidth - 1L))

--- a/tests/testthat/test-pet.R
+++ b/tests/testthat/test-pet.R
@@ -72,7 +72,7 @@ CHECKFUN <- function(npairs, nsingles, chromosomes, param) {
 
 .make_gr <- function(df, chromos) {
     maxed <- chromos[df$rname]
-    alen <- GenomicAlignments::cigarWidthAlongReferenceSpace(df$cigar)
+    alen <- cigarillo::cigar_extent_along_ref(df$cigar)
     GRanges(df$rname, IRanges(df$pos, pmin(maxed, df$pos + alen - 1L)))
 }
 


### PR DESCRIPTION
This fixes https://bioconductor.org/checkResults/3.24/bioc-LATEST/csaw/nebbiolo2-checksrc.html